### PR TITLE
Update Trails production impact

### DIFF
--- a/_data/cv.yaml
+++ b/_data/cv.yaml
@@ -16,7 +16,7 @@ sections:
       content:
         - "Led implementation and release integration for the Quantstamp-reviewed Trails v1.5 smart contracts, a stateless and ownerless intent-execution architecture built on Sequence Wallet V3"
         - "Built runtime calldata hydration, delegated-extension support, asset sweeping and audit remediations to enable composable bridge, swap and DeFi workflows"
-        - "Helped scale Trails beyond US$200M in reported transaction volume and approximately 500 developers; v1.5 recorded 22,000+ successful intents and nearly 33,000 onchain transactions across 17 observed mainnets by August 2026"
+        - "Helped scale Trails to hundreds of millions of US dollars in successful production volume, more than one hundred thousand successful intents, tens of thousands of successful wallets and hundreds of developers"
         - "Developed Sequence Wallet V3, its Sessions protocol and the contract library for Sequence Builder ecosystems"
         - "Co-author of ERC-5189, a flexible alternative to ERC-4337 account abstraction"
     - title: "Altered State Machine (Futureverse)"


### PR DESCRIPTION
## Summary
- replace early v1.5 snapshot metrics with current lifetime production impact
- keep the CV figures deliberately rounded and non-exact
- distinguish successful intents and wallets without presenting wallets as users

## Verification
- ✔ YAML Lint successful.
- checked the updated impact bullet contains no numeric digits