### PR TITLE
docs(cv): update Futureverse company name

### DIFF
--- a/_data/cv.yaml
+++ b/_data/cv.yaml
@@ -19,7 +19,7 @@ sections:
         - "Helped scale Trails to over US$230M in successful production volume, more than one hundred thousand successful intents, tens of thousands of successful wallets and hundreds of developers"
         - "Developed Sequence Wallet V3, its Sessions protocol and the contract library for Sequence Builder ecosystems"
         - "Co-author of ERC-5189, a flexible alternative to ERC-4337 account abstraction"
-    - title: "Altered State Machine (Futureverse)"
+    - title: "Futureverse (formerly Altered State Machine)"
       blurb: "Web3 Engineer"
       date: "2022 - 2023"
       content:


### PR DESCRIPTION
## Summary
- Rename the CV entry to Futureverse
- Preserve the former Altered State Machine name for context

## Verification
- `git diff --check`
- YAML lint passed during the targeted edit

Local Jekyll build was unavailable because Ruby/Bundler are not installed on the host; GitHub Pages will perform the canonical build.