### PR TITLE
Update Polygon role to Staff Blockchain Engineer

### DIFF
--- a/_data/cv.yaml
+++ b/_data/cv.yaml
@@ -11,7 +11,7 @@ sections:
     pageBreakAfter: true
     content:
     - title: "Polygon Labs (formerly Sequence)"
-      blurb: "Senior Smart Contract Engineer"
+      blurb: "Staff Blockchain Engineer"
       date: "2023 - Present"
       content:
         - "Led implementation and release integration for the Quantstamp-reviewed Trails v1.5 smart contracts, a stateless and ownerless intent-execution architecture built on Sequence Wallet V3"


### PR DESCRIPTION
## Summary
- update the Polygon Labs role title to Staff Blockchain Engineer

## Verification
- parsed `_data/cv.yaml` with PyYAML
- confirmed the rendered CV data contains the new role title
- ran `git diff --check`