### PR TITLE
Update AI hobby on CV

### DIFF
--- a/_data/cv.yaml
+++ b/_data/cv.yaml
@@ -116,7 +116,7 @@ sections:
     content:
     - content:
        - "Ethereum and blockchain"
-       - "AI content creation (text and images)"
+       - "AI automation and harness engineering"
        - "Bouldering and running"
        - "Spending time with the family"
   - title: "References"


### PR DESCRIPTION
## Summary
- replace AI content creation with AI automation and harness engineering under Interests and Hobbies

## Verification
- parsed `_data/cv.yaml` with PyYAML
- confirmed the new hobby is present and the old wording is absent
- ran `git diff --check`