### PR TITLE
Add AI-driven development to Polygon CV entry

### DIFF
--- a/_data/cv.yaml
+++ b/_data/cv.yaml
@@ -17,6 +17,7 @@ sections:
         - "Led implementation and release integration for the Quantstamp-reviewed Trails v1.5 smart contracts, a stateless and ownerless intent-execution architecture built on Sequence Wallet V3"
         - "Built runtime calldata hydration, delegated-extension support, asset sweeping and audit remediations to enable composable bridge, swap and DeFi workflows"
         - "Helped scale Trails to over US$230M in successful production volume, more than one hundred thousand successful intents, tens of thousands of successful wallets and hundreds of developers"
+        - "Applied AI-driven development practices using iterative review, testing and implementation harnesses, local workflow automation and reporting"
         - "Developed Sequence Wallet V3, its Sessions protocol and the contract library for Sequence Builder ecosystems"
         - "Co-author of ERC-5189, a flexible alternative to ERC-4337 account abstraction"
     - title: "Futureverse (formerly Altered State Machine)"


### PR DESCRIPTION
## Summary
- add a concise, intentionally high-level description of AI-driven development practices under Polygon Labs
- mention iterative review/testing/implementation harnesses, local workflow automation, and reporting

## Verification
- parsed `_data/cv.yaml` successfully with `js-yaml`
- `git diff --check` passed

## Local build
- not run: Ruby is unavailable on the host and the current user cannot access the Docker daemon; the canonical GitHub Pages build will verify the rendered site after merge